### PR TITLE
feat: Explorer Indexer

### DIFF
--- a/near-hat-cli/src/main.rs
+++ b/near-hat-cli/src/main.rs
@@ -40,6 +40,13 @@ async fn main() -> anyhow::Result<()> {
                 "  Lake Indexer S3 Bucket: {}",
                 near_hat.lake_indexer_ctx.localstack.s3_bucket
             );
+            println!(
+                "  Explorer Database: {}",
+                near_hat
+                    .explorer_indexer_ctx
+                    .explorer_database
+                    .host_postgres_connection_string()
+            );
 
             println!("\nPress any button to exit and destroy all containers...");
             while stdin().read(&mut [0]).await? == 0 {

--- a/near-hat/src/containers/explorer_database.rs
+++ b/near-hat/src/containers/explorer_database.rs
@@ -14,7 +14,7 @@ impl<'a> ExplorerDatabase<'a> {
     ) -> anyhow::Result<ExplorerDatabase<'a>> {
         tracing::info!(network, "starting NEAR Explorer Database container");
 
-        let image = GenericImage::new("explorer-database", "latest").with_wait_for(
+        let image = GenericImage::new("morgsmccauley/explorer-database", "latest").with_wait_for(
             WaitFor::message_on_stdout("database system is ready to accept connections"),
         );
 

--- a/near-hat/src/containers/explorer_database.rs
+++ b/near-hat/src/containers/explorer_database.rs
@@ -1,0 +1,41 @@
+use crate::DockerClient;
+use testcontainers::core::WaitFor;
+use testcontainers::{Container, GenericImage, RunnableImage};
+
+pub struct ExplorerDatabase<'a> {
+    pub container: Container<'a, GenericImage>,
+    pub connection_string: String,
+}
+
+impl<'a> ExplorerDatabase<'a> {
+    pub async fn run(
+        docker_client: &'a DockerClient,
+        network: &str,
+    ) -> anyhow::Result<ExplorerDatabase<'a>> {
+        tracing::info!(network, "starting NEAR Explorer Database container");
+
+        let image = GenericImage::new("explorer-database", "latest").with_wait_for(
+            WaitFor::message_on_stdout("database system is ready to accept connections"),
+        );
+
+        let image: RunnableImage<GenericImage> = (image, vec![]).into();
+        let image = image.with_network(network);
+        let container = docker_client.cli.run(image);
+
+        let ip_address = docker_client
+            .get_network_ip_address(&container, network)
+            .await?;
+
+        let connection_string = format!(
+            "postgres://postgres:postgres@{}:{}/postgres",
+            ip_address, 5432
+        );
+
+        tracing::info!("NEAR Explorer Database container is running");
+
+        Ok(ExplorerDatabase {
+            container,
+            connection_string,
+        })
+    }
+}

--- a/near-hat/src/containers/explorer_indexer.rs
+++ b/near-hat/src/containers/explorer_indexer.rs
@@ -1,89 +1,37 @@
-use crate::validator::ValidatorContainer;
 use crate::DockerClient;
 use testcontainers::core::WaitFor;
 use testcontainers::{Container, GenericImage, RunnableImage};
 
 pub struct ExplorerIndexer<'a> {
     pub container: Container<'a, GenericImage>,
-    pub bucket_name: String,
-    pub region: String,
-    pub rpc_address: String,
 }
 
 impl<'a> ExplorerIndexer<'a> {
-    pub const CONTAINER_RPC_PORT: u16 = 3030;
-
     pub async fn run(
         docker_client: &'a DockerClient,
         network: &str,
-        s3_address: &str,
-        bucket_name: String,
-        region: String,
     ) -> anyhow::Result<ExplorerIndexer<'a>> {
-        tracing::info!(
-            network,
-            s3_address,
-            bucket_name,
-            region,
-            "starting NEAR Lake Indexer container"
-        );
+        tracing::info!(network, "starting NEAR Lake Indexer container");
 
         let image = GenericImage::new(
-            "ghcr.io/near/near-lake-indexer",
-            "e6519c922435f3d18b5f2ddac5d1ec171ef4dd6b",
+            "us-central1-docker.pkg.dev/pagoda-data-stack-dev/cloud-run-source-deploy/indexer-explorer",
+            "439ccdab3dfa60f503bf1ddcc4498595d5ad6339",
         )
         .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
         .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
-        .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"))
-        .with_exposed_port(Self::CONTAINER_RPC_PORT);
+        .with_env_var("DATABASE_URL", "test")
+        .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"));
+
         let image: RunnableImage<GenericImage> = (
             image,
-            vec![
-                "--endpoint".to_string(),
-                s3_address.to_string(),
-                "--bucket".to_string(),
-                bucket_name.clone(),
-                "--region".to_string(),
-                region.clone(),
-                "--stream-while-syncing".to_string(),
-                "sync-from-latest".to_string(),
-            ],
+            vec!["mainnet".to_string(), "from-genesis".to_string()],
         )
             .into();
         let image = image.with_network(network);
         let container = docker_client.cli.run(image);
-        let ip_address = docker_client
-            .get_network_ip_address(&container, network)
-            .await?;
-        let rpc_address = format!("http://{}:{}", ip_address, Self::CONTAINER_RPC_PORT);
 
-        tracing::info!(
-            bucket_name,
-            region,
-            rpc_address,
-            "NEAR Lake Indexer container is running"
-        );
-        Ok(ExplorerIndexer {
-            container,
-            bucket_name,
-            region,
-            rpc_address,
-        })
-    }
+        tracing::info!("NEAR Explorer Indexer container is running");
 
-    pub fn host_rpc_address_ipv4(&self) -> String {
-        let host_port = self.container.get_host_port_ipv4(Self::CONTAINER_RPC_PORT);
-        format!("http://127.0.0.1:{host_port}")
-    }
-
-    pub fn host_rpc_address_ipv6(&self) -> String {
-        let host_port = self.container.get_host_port_ipv6(Self::CONTAINER_RPC_PORT);
-        format!("http://[::1]:{host_port}")
-    }
-}
-
-impl<'a> ValidatorContainer<'a> for ExplorerIndexer<'a> {
-    fn validator_container(&self) -> &Container<'a, GenericImage> {
-        &self.container
+        Ok(ExplorerIndexer { container })
     }
 }

--- a/near-hat/src/containers/explorer_indexer.rs
+++ b/near-hat/src/containers/explorer_indexer.rs
@@ -1,0 +1,89 @@
+use crate::validator::ValidatorContainer;
+use crate::DockerClient;
+use testcontainers::core::WaitFor;
+use testcontainers::{Container, GenericImage, RunnableImage};
+
+pub struct ExplorerIndexer<'a> {
+    pub container: Container<'a, GenericImage>,
+    pub bucket_name: String,
+    pub region: String,
+    pub rpc_address: String,
+}
+
+impl<'a> ExplorerIndexer<'a> {
+    pub const CONTAINER_RPC_PORT: u16 = 3030;
+
+    pub async fn run(
+        docker_client: &'a DockerClient,
+        network: &str,
+        s3_address: &str,
+        bucket_name: String,
+        region: String,
+    ) -> anyhow::Result<ExplorerIndexer<'a>> {
+        tracing::info!(
+            network,
+            s3_address,
+            bucket_name,
+            region,
+            "starting NEAR Lake Indexer container"
+        );
+
+        let image = GenericImage::new(
+            "ghcr.io/near/near-lake-indexer",
+            "e6519c922435f3d18b5f2ddac5d1ec171ef4dd6b",
+        )
+        .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
+        .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
+        .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"))
+        .with_exposed_port(Self::CONTAINER_RPC_PORT);
+        let image: RunnableImage<GenericImage> = (
+            image,
+            vec![
+                "--endpoint".to_string(),
+                s3_address.to_string(),
+                "--bucket".to_string(),
+                bucket_name.clone(),
+                "--region".to_string(),
+                region.clone(),
+                "--stream-while-syncing".to_string(),
+                "sync-from-latest".to_string(),
+            ],
+        )
+            .into();
+        let image = image.with_network(network);
+        let container = docker_client.cli.run(image);
+        let ip_address = docker_client
+            .get_network_ip_address(&container, network)
+            .await?;
+        let rpc_address = format!("http://{}:{}", ip_address, Self::CONTAINER_RPC_PORT);
+
+        tracing::info!(
+            bucket_name,
+            region,
+            rpc_address,
+            "NEAR Lake Indexer container is running"
+        );
+        Ok(ExplorerIndexer {
+            container,
+            bucket_name,
+            region,
+            rpc_address,
+        })
+    }
+
+    pub fn host_rpc_address_ipv4(&self) -> String {
+        let host_port = self.container.get_host_port_ipv4(Self::CONTAINER_RPC_PORT);
+        format!("http://127.0.0.1:{host_port}")
+    }
+
+    pub fn host_rpc_address_ipv6(&self) -> String {
+        let host_port = self.container.get_host_port_ipv6(Self::CONTAINER_RPC_PORT);
+        format!("http://[::1]:{host_port}")
+    }
+}
+
+impl<'a> ValidatorContainer<'a> for ExplorerIndexer<'a> {
+    fn validator_container(&self) -> &Container<'a, GenericImage> {
+        &self.container
+    }
+}

--- a/near-hat/src/containers/explorer_indexer.rs
+++ b/near-hat/src/containers/explorer_indexer.rs
@@ -24,7 +24,7 @@ impl<'a> ExplorerIndexer<'a> {
             "starting NEAR Explorer Indexer container"
         );
 
-        let image = GenericImage::new("explorer", "latest")
+        let image = GenericImage::new("morgsmccauley/explorer-indexer", "latest")
             .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
             .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
             .with_env_var("DATABASE_URL", database_url)

--- a/near-hat/src/containers/explorer_indexer.rs
+++ b/near-hat/src/containers/explorer_indexer.rs
@@ -13,19 +13,21 @@ impl<'a> ExplorerIndexer<'a> {
         s3_endpoint: &str,
         s3_bucket: &str,
         s3_region: &str,
+        database_url: &str,
     ) -> anyhow::Result<ExplorerIndexer<'a>> {
         tracing::info!(
             network,
             s3_endpoint,
             s3_bucket,
             s3_region,
+            database_url,
             "starting NEAR Explorer Indexer container"
         );
 
         let image = GenericImage::new("explorer", "latest")
             .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
             .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
-            .with_env_var("DATABASE_URL", "test")
+            .with_env_var("DATABASE_URL", database_url)
             .with_env_var("S3_REGION", s3_region)
             .with_env_var("AWS_REGION", s3_region)
             .with_env_var("S3_URL", s3_endpoint)

--- a/near-hat/src/containers/mod.rs
+++ b/near-hat/src/containers/mod.rs
@@ -1,3 +1,4 @@
+pub mod explorer_database;
 pub mod explorer_indexer;
 pub mod lake_indexer;
 pub mod localstack;

--- a/near-hat/src/containers/mod.rs
+++ b/near-hat/src/containers/mod.rs
@@ -1,3 +1,4 @@
+pub mod explorer_indexer;
 pub mod lake_indexer;
 pub mod localstack;
 pub mod redis;

--- a/near-hat/src/ctx/explorer_indexer.rs
+++ b/near-hat/src/ctx/explorer_indexer.rs
@@ -1,9 +1,11 @@
 use super::lake_indexer::LakeIndexerCtx;
 use crate::client::DockerClient;
+use crate::containers::explorer_database::ExplorerDatabase;
 use crate::containers::explorer_indexer::ExplorerIndexer;
 
 pub struct ExplorerIndexerCtx<'a> {
     pub explorer_indexer: ExplorerIndexer<'a>,
+    pub explorer_database: ExplorerDatabase<'a>,
 }
 
 impl<'a> ExplorerIndexerCtx<'a> {
@@ -12,6 +14,7 @@ impl<'a> ExplorerIndexerCtx<'a> {
         network: &str,
         lake_indexer_ctx: &LakeIndexerCtx<'a>,
     ) -> anyhow::Result<ExplorerIndexerCtx<'a>> {
+        let explorer_database = ExplorerDatabase::run(docker_client, network).await?;
 
         let explorer_indexer = ExplorerIndexer::run(
             docker_client,
@@ -19,11 +22,13 @@ impl<'a> ExplorerIndexerCtx<'a> {
             &lake_indexer_ctx.localstack.s3_address,
             &lake_indexer_ctx.localstack.s3_bucket,
             &lake_indexer_ctx.localstack.s3_region,
+            &explorer_database.connection_string,
         )
         .await?;
 
         Ok(ExplorerIndexerCtx {
             explorer_indexer,
+            explorer_database,
         })
     }
 }

--- a/near-hat/src/ctx/explorer_indexer.rs
+++ b/near-hat/src/ctx/explorer_indexer.rs
@@ -1,9 +1,8 @@
+use super::lake_indexer::LakeIndexerCtx;
 use crate::client::DockerClient;
 use crate::containers::explorer_indexer::ExplorerIndexer;
-use crate::containers::localstack::LocalStack;
 
 pub struct ExplorerIndexerCtx<'a> {
-    pub localstack: LocalStack<'a>,
     pub explorer_indexer: ExplorerIndexer<'a>,
 }
 
@@ -11,16 +10,19 @@ impl<'a> ExplorerIndexerCtx<'a> {
     pub async fn new(
         docker_client: &'a DockerClient,
         network: &str,
+        lake_indexer_ctx: &LakeIndexerCtx<'a>,
     ) -> anyhow::Result<ExplorerIndexerCtx<'a>> {
-        let s3_bucket = "near-lake-custom".to_string();
-        let s3_region = "us-east-1".to_string();
-        let localstack =
-            LocalStack::run(docker_client, network, s3_bucket.clone(), s3_region.clone()).await?;
 
-        let explorer_indexer = ExplorerIndexer::run(docker_client, network).await?;
+        let explorer_indexer = ExplorerIndexer::run(
+            docker_client,
+            network,
+            &lake_indexer_ctx.localstack.s3_address,
+            &lake_indexer_ctx.localstack.s3_bucket,
+            &lake_indexer_ctx.localstack.s3_region,
+        )
+        .await?;
 
         Ok(ExplorerIndexerCtx {
-            localstack,
             explorer_indexer,
         })
     }

--- a/near-hat/src/ctx/explorer_indexer.rs
+++ b/near-hat/src/ctx/explorer_indexer.rs
@@ -1,0 +1,27 @@
+use crate::client::DockerClient;
+use crate::containers::explorer_indexer::ExplorerIndexer;
+use crate::containers::localstack::LocalStack;
+
+pub struct ExplorerIndexerCtx<'a> {
+    pub localstack: LocalStack<'a>,
+    pub explorer_indexer: ExplorerIndexer<'a>,
+}
+
+impl<'a> ExplorerIndexerCtx<'a> {
+    pub async fn new(
+        docker_client: &'a DockerClient,
+        network: &str,
+    ) -> anyhow::Result<ExplorerIndexerCtx<'a>> {
+        let s3_bucket = "near-lake-custom".to_string();
+        let s3_region = "us-east-1".to_string();
+        let localstack =
+            LocalStack::run(docker_client, network, s3_bucket.clone(), s3_region.clone()).await?;
+
+        let explorer_indexer = ExplorerIndexer::run(docker_client, network).await?;
+
+        Ok(ExplorerIndexerCtx {
+            localstack,
+            explorer_indexer,
+        })
+    }
+}

--- a/near-hat/src/ctx/mod.rs
+++ b/near-hat/src/ctx/mod.rs
@@ -1,3 +1,4 @@
+pub mod explorer_indexer;
 pub mod lake_indexer;
 pub mod nearcore;
 pub mod relayer;

--- a/near-hat/src/lib.rs
+++ b/near-hat/src/lib.rs
@@ -25,7 +25,8 @@ impl<'a> NearHat<'a> {
         let lake_indexer_ctx = LakeIndexerCtx::new(&docker_client, network).await?;
         let nearcore_ctx = NearcoreCtx::new(&lake_indexer_ctx.worker).await?;
         let relayer_ctx = RelayerCtx::new(&docker_client, network, &nearcore_ctx).await?;
-        let explorer_indexer_ctx = ExplorerIndexerCtx::new(docker_client, network).await?;
+        let explorer_indexer_ctx =
+            ExplorerIndexerCtx::new(docker_client, network, &lake_indexer_ctx).await?;
 
         Ok(NearHat {
             lake_indexer_ctx,

--- a/near-hat/src/lib.rs
+++ b/near-hat/src/lib.rs
@@ -5,6 +5,7 @@ mod validator;
 
 pub use client::DockerClient;
 
+use ctx::explorer_indexer::ExplorerIndexerCtx;
 use ctx::lake_indexer::LakeIndexerCtx;
 use ctx::nearcore::NearcoreCtx;
 use ctx::relayer::RelayerCtx;
@@ -13,6 +14,7 @@ pub struct NearHat<'a> {
     pub lake_indexer_ctx: LakeIndexerCtx<'a>,
     pub nearcore_ctx: NearcoreCtx,
     pub relayer_ctx: RelayerCtx<'a>,
+    pub explorer_indexer_ctx: ExplorerIndexerCtx<'a>,
 }
 
 impl<'a> NearHat<'a> {
@@ -23,11 +25,13 @@ impl<'a> NearHat<'a> {
         let lake_indexer_ctx = LakeIndexerCtx::new(&docker_client, network).await?;
         let nearcore_ctx = NearcoreCtx::new(&lake_indexer_ctx.worker).await?;
         let relayer_ctx = RelayerCtx::new(&docker_client, network, &nearcore_ctx).await?;
+        let explorer_indexer_ctx = ExplorerIndexerCtx::new(docker_client, network).await?;
 
         Ok(NearHat {
             lake_indexer_ctx,
             nearcore_ctx,
             relayer_ctx,
+            explorer_indexer_ctx,
         })
     }
 }


### PR DESCRIPTION
Adds explorer indexer & database containers. These reference locally built images, so will need to push them somewhere before merging.

Depends on https://github.com/near/near-indexer-for-explorer/tree/feat/neat-hat which itself depends on https://github.com/near/near-lake-framework-rs/tree/upgrade-s3-sdk-0.7.1.